### PR TITLE
Xfce4 fixes

### DIFF
--- a/gtk-2.0/apps/xfce.rc
+++ b/gtk-2.0/apps/xfce.rc
@@ -6,10 +6,10 @@ style "theme-panel" = "dark" {
 style "xfdesktop-icon-view" {
 	XfdesktopIconView::label-alpha = 0
 	XfdesktopIconView::selected-label-alpha = 80
-	XfdesktopIconView::shadow-x-offset = 1
-	XfdesktopIconView::shadow-y-offset = 1
-	XfdesktopIconView::selected-shadow-x-offset = 1
-	XfdesktopIconView::selected-shadow-y-offset = 1
+	XfdesktopIconView::shadow-x-offset = 0
+	XfdesktopIconView::shadow-y-offset = 0
+	XfdesktopIconView::selected-shadow-x-offset = 0
+	XfdesktopIconView::selected-shadow-y-offset = 0
 	XfdesktopIconView::shadow-color = @tooltip_bg_color
 	XfdesktopIconView::selected-shadow-color = @tooltip_bg_color
 	XfdesktopIconView::cell-spacing = 2

--- a/gtk-2.0/main.rc
+++ b/gtk-2.0/main.rc
@@ -2400,14 +2400,14 @@ style "frame" {
     image {
       function = SHADOW
       file     = "assets/frame.png"
-      border   = {1, 1, 1, 1}
+      border   = {0, 0, 0, 0}
       stretch  = TRUE
     }
 
     image {
       function       = SHADOW_GAP
       file           = "assets/frame.png"
-      border         = {1, 1, 1, 1}
+      border         = {0, 0, 0, 0}
       stretch        = TRUE
       gap_start_file = "assets/border.png"
       gap_end_file   = "assets/border.png"

--- a/xfwm4/themerc
+++ b/xfwm4/themerc
@@ -10,8 +10,8 @@ title_vertical_offset_inactive=1
 title_shadow_active=false
 title_shadow_inactive=false
 
-active_text_color=#ECEFF1
-active_text_shadow_color=#ECEFF1
+active_text_color=#ff5d73
+active_text_shadow_color=#ff5d73
 inactive_text_color=#778085
 inactive_text_shadow_color=#778085
 

--- a/xfwm4/themerc
+++ b/xfwm4/themerc
@@ -1,4 +1,4 @@
-#button_layout=O|HMC
+button_layout=O|MHC
 button_offset=2
 button_spacing=2
 

--- a/xfwm4/themerc
+++ b/xfwm4/themerc
@@ -1,4 +1,4 @@
-button_layout=O|MHC
+#button_layout=O|MHC
 button_offset=2
 button_spacing=2
 

--- a/xfwm4/themerc
+++ b/xfwm4/themerc
@@ -10,8 +10,8 @@ title_vertical_offset_inactive=1
 title_shadow_active=false
 title_shadow_inactive=false
 
-active_text_color=#ff5d73
-active_text_shadow_color=#ff5d73
+active_text_color=#31363D
+active_text_shadow_color=#31363D
 inactive_text_color=#778085
 inactive_text_shadow_color=#778085
 


### PR DESCRIPTION
This is one of the prettiest themes I've seen in a long time, kudos!

I have a few minor peeves with the xfce4 part, however, for which I propose fixes in this PR. Each issue is illustrated below and addressed in its own commit, so that you can cherry-pick as needed/wanted. Note that to see the effect of any of these when running xfce, you'll first have to uncomment the `include "apps/xfce.rc"` in Ant/gtk-2.0/gtkrc.

- **icon shadows:** these look wrong to me (I find the blur irritating), so I just removed them.

    **before:**
![desktop-icons-before](https://user-images.githubusercontent.com/2853977/35187671-cfaf8000-fe27-11e7-9db2-0a63b015cc14.png)
  **after:** 
![desktop-icons-after](https://user-images.githubusercontent.com/2853977/35187683-f0b115f2-fe27-11e7-858f-4bcd0c531cc6.png)

- **systray border:** removed the ugly 1-pixel border around the xfce systray.
   **before:**
![systray-before](https://user-images.githubusercontent.com/2853977/35187694-278e2416-fe28-11e7-8e2b-028316f0d6ae.png)
    **after:**
![systray-after](https://user-images.githubusercontent.com/2853977/35187696-339ad3ee-fe28-11e7-853d-f9324c81505e.png)

- **window button order:** changed to the Mac-like red-yellow-green "traffic light" order that I also see in the Gnome version of the theme (yeah, it's a minor niggle, but I also use macOS, so I do find the "wrong" order irritating).
    **before:**
![buttons-before](https://user-images.githubusercontent.com/2853977/35187729-bc67b71e-fe28-11e7-9ca1-efd44887ba8f.png)
    **after:**
![buttons-after](https://user-images.githubusercontent.com/2853977/35187730-c7610d00-fe28-11e7-8e53-5d4a2e6e3fa2.png)

- **active window title:** the text comes out as light gray on (the same) light gray in the base version of the theme, which is a bit hard to read. 😄 From the Gnome screenshot it seemed to me that the pink selection color in the active window title might look nice, so that's what I did there for now. (On second thought, it should probably be a darker gray instead? I'll have to look in the gtk-3.0 part of the theme to figure that out so that I can augment the PR accordingly.)
    **before:**
![titlebar-before](https://user-images.githubusercontent.com/2853977/35187762-4318a520-fe29-11e7-9ffc-6543c6bf26c8.png)
    **after:**
![titlebar-after](https://user-images.githubusercontent.com/2853977/35187764-693eb212-fe29-11e7-9c85-130b3aa877e0.png)

So there you have it. Again, thanks for creating this wonderful theme! I also like Evopop on which it is based, but Evopop has some issues with the latest Gnome even the latest git revision, and since I'm running Arch these annoy me because of the css glitches GTK warns me about every time I launch emacs from the command line. And in any case the colors in your theme (also the nebula/bloody/dracula variants) look nicer.

Ever since the big changes of the GTK theming engine there's been a shortage of good-looking themes that actually *work* with xfce. Your theme fills that gap for me, so I thought that I'd contribute these fixes in case someone else might find them useful.